### PR TITLE
feat: 성능 최적화 - Core Web Vitals 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,19 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/fonts/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/(record)/layout.tsx
+++ b/src/app/(record)/layout.tsx
@@ -1,0 +1,10 @@
+import "react-notion-x/src/styles.css";
+import "../styles/prism-dracula.css";
+
+export default function RecordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,16 +1,7 @@
-"use client";
-
 import Link from "next/link";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
-  function changeColorScheme() {
-    const $html = document.getElementsByTagName("html").item(0);
-
-    if ($html) {
-      $html.dataset.theme = $html.dataset.theme === "pink" ? "blue" : "pink";
-    }
-  }
-
   return (
     <header className="bg-header-bg border-b-main-200 sticky top-0 z-1 border-b py-2">
       <nav className="mx-auto max-w-[768px] px-4 lg:px-0">
@@ -21,11 +12,7 @@ export default function Header() {
             </Link>
           </li>
           <li className="ml-0 min-[375px]:ml-8 md:ml-0">
-            <button
-              title="색 바꾸기"
-              className="bg-main-500 block h-6 w-6 cursor-pointer rounded-full md:h-8 md:w-8"
-              onClick={changeColorScheme}
-            />
+            <ThemeToggle />
           </li>
           <li>
             <Link href="/about" className="text-lg break-keep md:text-2xl">

--- a/src/app/components/NotionPage.tsx
+++ b/src/app/components/NotionPage.tsx
@@ -6,8 +6,12 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 
-const Code = dynamic(() =>
-  import("react-notion-x/build/third-party/code").then((m) => m.Code),
+const Code = dynamic(
+  () => import("react-notion-x/build/third-party/code").then((m) => m.Code),
+  {
+    ssr: false,
+    loading: () => <div className="h-8 animate-pulse rounded bg-gray-200" />,
+  },
 );
 
 export function NotionPage({

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export default function ThemeToggle() {
+  function changeColorScheme() {
+    const $html = document.getElementsByTagName("html").item(0);
+
+    if ($html) {
+      $html.dataset.theme = $html.dataset.theme === "pink" ? "blue" : "pink";
+    }
+  }
+
+  return (
+    <button
+      title="색 바꾸기"
+      className="bg-main-500 block h-6 w-6 cursor-pointer rounded-full md:h-8 md:w-8"
+      onClick={changeColorScheme}
+    />
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
-import "react-notion-x/src/styles.css";
+import { Gowun_Dodum } from "next/font/google";
 import "./styles/globals.css";
-import "./styles/prism-dracula.css";
 import Header from "@/app/components/Header";
 import Footer from "@/app/components/Footer";
 import QueryProvider from "@/app/providers/query-provider";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+
+const gowunDodum = Gowun_Dodum({
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-gowun-dodum",
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.einere.me"),
@@ -43,7 +49,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" data-theme="pink">
+    <html lang="ko" data-theme="pink" className={gowunDodum.variable}>
       <body className="antialiased">
         <QueryProvider>
           <Header />

--- a/src/app/lib/notionCompatAPI.ts
+++ b/src/app/lib/notionCompatAPI.ts
@@ -1,11 +1,20 @@
 import { Client } from "@notionhq/client";
 import { NotionCompatAPI } from "notion-compat";
+import { cache } from "react";
 
 const notionClient = new Client({
   auth: process.env.NEXT_NOTION_API_AUTH_TOKEN,
+  fetch: (url, init) => {
+    return fetch(url, {
+      ...init,
+      next: {
+        revalidate: 1800, // 30분마다 재검증
+      },
+    });
+  },
 });
 const notionCompatAPI = new NotionCompatAPI(notionClient);
 
-export function getPageByPageId(pageId: string) {
+export const getPageByPageId = cache((pageId: string) => {
   return notionCompatAPI.getPage(pageId);
-}
+});

--- a/src/app/providers/query-provider.tsx
+++ b/src/app/providers/query-provider.tsx
@@ -10,7 +10,7 @@ export default function QueryProvider({ children }: { children: ReactNode }) {
   return (
     <QueryClientProvider client={client}>
       {children}
-      <ReactQueryDevtools />
+      {process.env.NODE_ENV === "development" && <ReactQueryDevtools />}
     </QueryClientProvider>
   );
 }

--- a/src/app/styles/font.css
+++ b/src/app/styles/font.css
@@ -15,14 +15,6 @@
 }
 
 @font-face {
-  font-family: "GowunDodum-Regular";
-  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/GowunDodum-Regular.woff")
-    format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
   font-family: "FZuanSu";
   src: url("/fonts/FZuanSu/FZuanSu-subset.woff2") format("woff2");
   font-display: swap;

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -10,8 +10,23 @@
     --notion-font: var(--font-sans) !important;
   }
 
+  /* Optimized transitions for theme switching and interactive elements */
   * {
-    @apply transition-colors;
+    @apply transition-colors duration-150 ease-in-out;
+  }
+
+  /* Disable transitions for performance-critical elements */
+  .no-transition,
+  .no-transition * {
+    transition: none !important;
+  }
+
+  /* Optimize transitions for specific performance-sensitive elements */
+  img,
+  video,
+  canvas,
+  svg {
+    transition: none;
   }
 
   html[data-theme="pink"] {

--- a/src/app/styles/theme.css
+++ b/src/app/styles/theme.css
@@ -1,7 +1,7 @@
 /* @NOTICE: https://tailwindcss.com/docs/theme */
 @theme {
   /* Font */
-  --font-sans: "GowunDodum-Regular";
+  --font-sans: var(--font-gowun-dodum);
   --font-mono: D2Coding;
   --font-chiness: FZuanSu;
 


### PR DESCRIPTION
- 외부 CDN 폰트를 next/font/google로 전환하여 렌더링 블로킹 제거
- Notion/Prism CSS를 (record) 레이아웃으로 이동하여 코드 스플리팅
- 폰트 캐싱 헤더 추가로 재방문 시 로딩 성능 향상

- React Query Devtools를 개발 환경에서만 로드
- Header 컴포넌트 클라이언트 로직을 ThemeToggle로 분리
- 전역 transition을 최적화하여 인터랙션 성능 개선(img, video 등의 요소는 트랜지션 비활성화)
- Code 컴포넌트에 적절한 loading 상태 및 SSR 비활성화

- records/[slug]에서 중복 API 호출 제거
- React cache() 함수로 데이터 공유 및 캐싱 개선
- NotionCompatAPI에 fetch 캐시 적용