### PR TITLE
fix: 노션 이미지 프록시 구현

### DIFF
--- a/src/app/(record)/records/[slug]/page.tsx
+++ b/src/app/(record)/records/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/app/utils/notionUtils";
 import { cache } from "react";
 import type { NotionBlockList } from "@/app/components/NotionRenderer/types";
+import { NotionImage } from "@/app/components/NotionImage";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -77,7 +78,10 @@ export default async function RecordPage({
   return (
     <>
       {/* Custom Notion Renderer */}
-      <NotionRenderer blocks={blockChildren as NotionBlockList} />
+      <NotionRenderer
+        blocks={blockChildren as NotionBlockList}
+        customImage={NotionImage}
+      />
       <Comments />
     </>
   );

--- a/src/app/(record)/records/[slug]/page.tsx
+++ b/src/app/(record)/records/[slug]/page.tsx
@@ -13,7 +13,6 @@ import {
   getTitleFromPageObject,
 } from "@/app/utils/notionUtils";
 import { cache } from "react";
-import type { NotionBlockList } from "@/app/components/NotionRenderer/types";
 import { NotionImage } from "@/app/components/NotionImage";
 
 type Props = {
@@ -78,10 +77,7 @@ export default async function RecordPage({
   return (
     <>
       {/* Custom Notion Renderer */}
-      <NotionRenderer
-        blocks={blockChildren as NotionBlockList}
-        customImage={NotionImage}
-      />
+      <NotionRenderer blocks={blockChildren} customImage={NotionImage} />
       <Comments />
     </>
   );

--- a/src/app/api/notion-image/route.ts
+++ b/src/app/api/notion-image/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { retrieveBlockChildren } from "@/app/lib/notionAPI";
 import { Client } from "@notionhq/client";
+import { isBlockObject } from "@/app/utils/notionUtils";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -17,17 +17,19 @@ export async function GET(request: NextRequest) {
     });
 
     // Get the specific block directly
-    const block = (await notion.blocks.retrieve({
+    const block = await notion.blocks.retrieve({
       block_id: blockId,
-    })) as any;
+    });
 
-    if (!block || block.type !== "image" || !block.image) {
+    // TOOD: isImageBlock 타입 가드 함수로 리팩토링하기
+    if (!isBlockObject(block) || block.type !== "image" || !block.image) {
       return NextResponse.json(
         { error: "Image block not found" },
         { status: 404 },
       );
     }
 
+    // TODO: FileMediaContentWithFileAndCaptionResponse 와 ExternalMediaContentWithFileAndCaptionResponse 를 구분하는 타입 가드 함수 적용하기
     const imageData = block.image;
     const fileUrl = imageData.file?.url;
     const externalUrl = imageData.external?.url;

--- a/src/app/api/notion-image/route.ts
+++ b/src/app/api/notion-image/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { retrieveBlockChildren } from "@/app/lib/notionAPI";
+import { Client } from "@notionhq/client";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const blockId = searchParams.get("blockId");
+
+  if (!blockId) {
+    return NextResponse.json({ error: "blockId is required" }, { status: 400 });
+  }
+
+  try {
+    // Create a new Notion client for this request
+    const notion = new Client({
+      auth: process.env.NEXT_NOTION_API_AUTH_TOKEN,
+    });
+
+    // Get the specific block directly
+    const block = (await notion.blocks.retrieve({
+      block_id: blockId,
+    })) as any;
+
+    if (!block || block.type !== "image" || !block.image) {
+      return NextResponse.json(
+        { error: "Image block not found" },
+        { status: 404 },
+      );
+    }
+
+    const imageData = block.image;
+    const fileUrl = imageData.file?.url;
+    const externalUrl = imageData.external?.url;
+    const imageUrl = fileUrl || externalUrl;
+
+    if (!imageUrl) {
+      return NextResponse.json(
+        { error: "No image URL found" },
+        { status: 404 },
+      );
+    }
+
+    // Fetch the image from the Notion URL
+    const imageResponse = await fetch(imageUrl);
+
+    if (!imageResponse.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch image" },
+        { status: imageResponse.status },
+      );
+    }
+
+    // Get the image data
+    const imageBuffer = await imageResponse.arrayBuffer();
+    const contentType =
+      imageResponse.headers.get("content-type") || "image/jpeg";
+
+    // Return the image with appropriate headers
+    return new NextResponse(imageBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=1800, s-maxage=1800", // 30분 캐시
+        "Content-Length": imageBuffer.byteLength.toString(),
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching Notion image:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/notion-image/route.ts
+++ b/src/app/api/notion-image/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Client } from "@notionhq/client";
-import { isBlockObject } from "@/app/utils/notionUtils";
+import {
+  getImageUrlFromImageData,
+  isImageBlock,
+} from "@/app/utils/notionUtils";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -21,19 +24,14 @@ export async function GET(request: NextRequest) {
       block_id: blockId,
     });
 
-    // TOOD: isImageBlock 타입 가드 함수로 리팩토링하기
-    if (!isBlockObject(block) || block.type !== "image" || !block.image) {
+    if (!isImageBlock(block)) {
       return NextResponse.json(
         { error: "Image block not found" },
         { status: 404 },
       );
     }
 
-    // TODO: FileMediaContentWithFileAndCaptionResponse 와 ExternalMediaContentWithFileAndCaptionResponse 를 구분하는 타입 가드 함수 적용하기
-    const imageData = block.image;
-    const fileUrl = imageData.file?.url;
-    const externalUrl = imageData.external?.url;
-    const imageUrl = fileUrl || externalUrl;
+    const imageUrl = getImageUrlFromImageData(block.image);
 
     if (!imageUrl) {
       return NextResponse.json(

--- a/src/app/components/NotionImage.tsx
+++ b/src/app/components/NotionImage.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Image from "next/image";
+
+interface NotionImageProps {
+  src: string;
+  alt: string;
+  style?: React.CSSProperties;
+}
+
+export function NotionImage({ src, alt, style }: NotionImageProps) {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={800}
+      height={600}
+      style={style}
+      className="notion-image"
+      priority={false}
+      placeholder="blur"
+      blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
+    />
+  );
+}

--- a/src/app/components/NotionRenderer/components/ColumnList.tsx
+++ b/src/app/components/NotionRenderer/components/ColumnList.tsx
@@ -40,7 +40,7 @@ export async function ColumnList({ block, customImage }: ColumnListProps) {
     const columnBlock = columnBlocks[i];
 
     // Calculate width as percentage
-    const width = `${columnBlock.column.width_ratio * 100}%`;
+    const width = `${(columnBlock.column.width_ratio ?? 1) * 100}%`;
 
     // Fetch children of this column
     let columnChildren: NotionBlock[] = [];

--- a/src/app/components/NotionRenderer/components/Image.tsx
+++ b/src/app/components/NotionRenderer/components/Image.tsx
@@ -23,7 +23,11 @@ export function ImageBlock({ block, customImage }: ImageProps) {
   // Handle file URLs
   const fileUrl = imageData.file?.url;
   const externalUrl = imageData.external?.url;
-  const imageUrl = fileUrl || externalUrl;
+
+  // Use proxy for Notion-hosted images (file URLs), keep external URLs as-is
+  const imageUrl = fileUrl
+    ? `/api/notion-image?blockId=${block.id}`
+    : externalUrl;
 
   if (!imageUrl) {
     return null;
@@ -38,7 +42,7 @@ export function ImageBlock({ block, customImage }: ImageProps) {
         {customImage ? (
           React.createElement(customImage, {
             src: imageUrl,
-            alt: "",
+            alt: caption.map((c) => c.plain_text).join(""),
             style: { objectFit: "contain" },
           })
         ) : (

--- a/src/app/components/NotionRenderer/components/Image.tsx
+++ b/src/app/components/NotionRenderer/components/Image.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { ImageBlock as ImageBlockType } from "../types";
 import { RichText } from "./RichText";
+import { getImageUrlFromImageData } from "@/app/utils/notionUtils";
 
 interface ImageProps {
   block: ImageBlockType;
@@ -15,20 +16,7 @@ interface ImageProps {
 
 export function ImageBlock({ block, customImage }: ImageProps) {
   const imageData = block.image;
-
-  if (!imageData) {
-    return null;
-  }
-
-  // Handle different image types based on the official API structure
-  let imageUrl: string | null = null;
-
-  // TODO: getImageUrlFromImageData 함수로 리팩토링하기
-  if (imageData.type === "file") {
-    imageUrl = `/api/notion-image?blockId=${block.id}`;
-  } else if (imageData.type === "external") {
-    imageUrl = imageData.external.url;
-  }
+  const imageUrl = getImageUrlFromImageData(imageData);
 
   if (!imageUrl) {
     return null;
@@ -36,6 +24,7 @@ export function ImageBlock({ block, customImage }: ImageProps) {
 
   // Get caption
   const caption = imageData.caption || [];
+  const captionStr = caption.map((c) => c.plain_text).join("");
 
   return (
     <figure className="notion-asset-wrapper notion-asset-wrapper-image">
@@ -43,14 +32,14 @@ export function ImageBlock({ block, customImage }: ImageProps) {
         {customImage ? (
           React.createElement(customImage, {
             src: imageUrl,
-            alt: caption.map((c) => c.plain_text).join(""),
+            alt: captionStr,
             style: { objectFit: "contain" },
           })
         ) : (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={imageUrl}
-            alt=""
+            alt={captionStr}
             style={{ width: "100%", height: "auto", objectFit: "contain" }}
           />
         )}

--- a/src/app/components/NotionRenderer/components/Image.tsx
+++ b/src/app/components/NotionRenderer/components/Image.tsx
@@ -20,14 +20,15 @@ export function ImageBlock({ block, customImage }: ImageProps) {
     return null;
   }
 
-  // Handle file URLs
-  const fileUrl = imageData.file?.url;
-  const externalUrl = imageData.external?.url;
+  // Handle different image types based on the official API structure
+  let imageUrl: string | null = null;
 
-  // Use proxy for Notion-hosted images (file URLs), keep external URLs as-is
-  const imageUrl = fileUrl
-    ? `/api/notion-image?blockId=${block.id}`
-    : externalUrl;
+  // TODO: getImageUrlFromImageData 함수로 리팩토링하기
+  if (imageData.type === "file") {
+    imageUrl = `/api/notion-image?blockId=${block.id}`;
+  } else if (imageData.type === "external") {
+    imageUrl = imageData.external.url;
+  }
 
   if (!imageUrl) {
     return null;

--- a/src/app/components/NotionRenderer/components/RichText.tsx
+++ b/src/app/components/NotionRenderer/components/RichText.tsx
@@ -1,3 +1,4 @@
+import { getLinkFromRichTextItem } from "@/app/utils/notionUtils";
 import { RichTextItem } from "../types";
 
 interface RichTextProps {
@@ -11,7 +12,7 @@ export function RichText({ value, className }: RichTextProps) {
   }
 
   const renderText = (text: RichTextItem, index: number): React.ReactNode => {
-    const { annotations, plain_text, href } = text;
+    const { annotations, plain_text } = text;
 
     let element: React.ReactNode = plain_text;
 
@@ -20,15 +21,8 @@ export function RichText({ value, className }: RichTextProps) {
     const needsColor = annotations.color && annotations.color !== "default";
     const needsBg = needsColor && annotations.color !== "default";
 
-    // TOOD: getLinkFromUrl 함수로 리팩토링하기
     // Handle links first
-    const linkUrl =
-      href ||
-      (text.type === "text"
-        ? typeof text.text?.link === "string"
-          ? text.text.link
-          : text.text?.link?.url
-        : null);
+    const linkUrl = getLinkFromRichTextItem(text);
 
     // Build the element with all decorations
     if (needsCode) {

--- a/src/app/components/NotionRenderer/components/RichText.tsx
+++ b/src/app/components/NotionRenderer/components/RichText.tsx
@@ -11,7 +11,7 @@ export function RichText({ value, className }: RichTextProps) {
   }
 
   const renderText = (text: RichTextItem, index: number): React.ReactNode => {
-    const { text: textContent, annotations, plain_text, href } = text;
+    const { annotations, plain_text, href } = text;
 
     let element: React.ReactNode = plain_text;
 
@@ -20,8 +20,15 @@ export function RichText({ value, className }: RichTextProps) {
     const needsColor = annotations.color && annotations.color !== "default";
     const needsBg = needsColor && annotations.color !== "default";
 
+    // TOOD: getLinkFromUrl 함수로 리팩토링하기
     // Handle links first
-    const linkUrl = href || textContent?.link;
+    const linkUrl =
+      href ||
+      (text.type === "text"
+        ? typeof text.text?.link === "string"
+          ? text.text.link
+          : text.text?.link?.url
+        : null);
 
     // Build the element with all decorations
     if (needsCode) {

--- a/src/app/components/NotionRenderer/types.ts
+++ b/src/app/components/NotionRenderer/types.ts
@@ -1,3 +1,23 @@
+// Import official types from @notionhq/client
+import type {
+  RichTextItemResponse,
+  BlockObjectResponse,
+  ListBlockChildrenResponse,
+  ParagraphBlockObjectResponse,
+  Heading1BlockObjectResponse,
+  Heading2BlockObjectResponse,
+  Heading3BlockObjectResponse,
+  BulletedListItemBlockObjectResponse,
+  NumberedListItemBlockObjectResponse,
+  ImageBlockObjectResponse,
+  CodeBlockObjectResponse,
+  TableBlockObjectResponse,
+  TableRowBlockObjectResponse,
+  ColumnListBlockObjectResponse,
+  ColumnBlockObjectResponse,
+} from "@notionhq/client";
+
+// Define color type based on official API (ApiColor is not exported)
 export type NotionColor =
   | "default"
   | "gray"
@@ -8,219 +28,46 @@ export type NotionColor =
   | "blue"
   | "purple"
   | "pink"
-  | "red";
+  | "red"
+  | "default_background"
+  | "gray_background"
+  | "brown_background"
+  | "orange_background"
+  | "yellow_background"
+  | "green_background"
+  | "blue_background"
+  | "purple_background"
+  | "pink_background"
+  | "red_background";
 
+// Define annotation type based on official API (AnnotationResponse is not exported)
 export interface Annotation {
-  bold?: boolean;
-  italic?: boolean;
-  strikethrough?: boolean;
-  underline?: boolean;
-  code?: boolean;
-  color?: NotionColor;
+  bold: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  underline: boolean;
+  code: boolean;
+  color: NotionColor;
 }
 
-export interface TextContent {
-  content: string;
-  link?: string | null;
-}
+// Re-export official types with custom names for backward compatibility
+export type RichTextItem = RichTextItemResponse;
+export type NotionBlock = BlockObjectResponse;
+export type NotionBlockList = ListBlockChildrenResponse;
 
-export interface RichTextItem {
-  type: "text" | "mention" | "equation";
-  text?: TextContent;
-  annotations: Annotation;
-  plain_text: string;
-  href?: string | null;
-}
-
-export type BlockType =
-  | "paragraph"
-  | "heading_1"
-  | "heading_2"
-  | "heading_3"
-  | "bulleted_list_item"
-  | "numbered_list_item"
-  | "to_do"
-  | "toggle"
-  | "image"
-  | "video"
-  | "file"
-  | "code"
-  | "quote"
-  | "callout"
-  | "table"
-  | "table_row"
-  | "divider"
-  | "bookmark"
-  | "column_list"
-  | "column";
-
-export interface Parent {
-  type: string;
-  page_id?: string;
-  workspace?: boolean;
-}
-
-// Base block properties that all blocks share
-interface BaseNotionBlock {
-  object: "block";
-  id: string;
-  parent: Parent;
-  created_time: string;
-  last_edited_time: string;
-  created_by: {
-    object: "user";
-    id: string;
-  };
-  last_edited_by: {
-    object: "user";
-    id: string;
-  };
-  has_children: boolean;
-  archived: boolean;
-  in_trash: boolean;
-}
-
-// File object for images and files
-interface FileObject {
-  file: {
-    url: string;
-    expiry_time: string;
-  };
-  external?: never;
-}
-
-interface ExternalObject {
-  external: {
-    url: string;
-  };
-  file?: never;
-}
-
-interface ImageData {
-  caption: RichTextItem[];
-  type: "file" | "external";
-  file?: FileObject["file"];
-  external?: ExternalObject["external"];
-}
-
-interface TableRowData {
-  cells: RichTextItem[][];
-}
-
-interface HeadingData {
-  rich_text: RichTextItem[];
-  is_toggleable?: boolean;
-  color?: NotionColor;
-}
-
-interface ParagraphData {
-  rich_text: RichTextItem[];
-  color?: NotionColor;
-}
-
-interface CodeData {
-  caption: RichTextItem[];
-  rich_text: RichTextItem[];
-  language: string;
-}
-
-// Distinguished union for different block types
-export interface ParagraphBlock extends BaseNotionBlock {
-  type: "paragraph";
-  paragraph: ParagraphData;
-}
-
-export interface Heading1Block extends BaseNotionBlock {
-  type: "heading_1";
-  heading_1: HeadingData;
-}
-
-export interface Heading2Block extends BaseNotionBlock {
-  type: "heading_2";
-  heading_2: HeadingData;
-}
-
-export interface Heading3Block extends BaseNotionBlock {
-  type: "heading_3";
-  heading_3: HeadingData;
-}
-
-export interface BulletedListItemBlock extends BaseNotionBlock {
-  type: "bulleted_list_item";
-  bulleted_list_item: {
-    rich_text: RichTextItem[];
-    color?: NotionColor;
-  };
-}
-
-export interface NumberedListItemBlock extends BaseNotionBlock {
-  type: "numbered_list_item";
-  numbered_list_item: {
-    rich_text: RichTextItem[];
-    color?: NotionColor;
-  };
-}
-
-export interface ImageBlock extends BaseNotionBlock {
-  type: "image";
-  image: ImageData;
-}
-
-export interface CodeBlock extends BaseNotionBlock {
-  type: "code";
-  code: CodeData;
-}
-
-export interface TableBlock extends BaseNotionBlock {
-  type: "table";
-  table: {
-    table_width: number;
-    has_column_header: boolean;
-    has_row_header: boolean;
-  };
-}
-
-export interface TableRowBlock extends BaseNotionBlock {
-  type: "table_row";
-  table_row: TableRowData;
-}
-
-export interface ColumnListBlock extends BaseNotionBlock {
-  type: "column_list";
-  column_list: object;
-}
-
-export interface ColumnBlock extends BaseNotionBlock {
-  type: "column";
-  column: {
-    width_ratio: number;
-  };
-}
-
-export type NotionBlock =
-  | ParagraphBlock
-  | Heading1Block
-  | Heading2Block
-  | Heading3Block
-  | BulletedListItemBlock
-  | NumberedListItemBlock
-  | ImageBlock
-  | CodeBlock
-  | TableBlock
-  | TableRowBlock
-  | ColumnListBlock
-  | ColumnBlock;
-
-export interface NotionBlockList {
-  object: "list";
-  results: NotionBlock[];
-  next_cursor: string | null;
-  has_more: boolean;
-  type?: string;
-  block?: Record<string, unknown>;
-  developer_survey?: string;
-  request_id?: string;
-}
+// Re-export specific block types
+export type ParagraphBlock = ParagraphBlockObjectResponse;
+export type Heading1Block = Heading1BlockObjectResponse;
+export type Heading2Block = Heading2BlockObjectResponse;
+export type Heading3Block = Heading3BlockObjectResponse;
+export type BulletedListItemBlock = BulletedListItemBlockObjectResponse;
+export type NumberedListItemBlock = NumberedListItemBlockObjectResponse;
+export type ImageBlock = ImageBlockObjectResponse;
+export type CodeBlock = CodeBlockObjectResponse;
+export type TableBlock = TableBlockObjectResponse;
+export type TableRowBlock = TableRowBlockObjectResponse;
+export type ColumnListBlock = ColumnListBlockObjectResponse;
+export type ColumnBlock = ColumnBlockObjectResponse;
 
 export interface NotionRendererProps {
   blocks: NotionBlockList;

--- a/src/app/utils/notionUtils.ts
+++ b/src/app/utils/notionUtils.ts
@@ -88,5 +88,9 @@ export function getFirstImageFromListBlockChildren(
   const blockChildren = listBlockChildrenResponse.results;
   const imageBlock = blockChildren.filter(isImageBlock)[0];
 
-  return imageBlock?.image?.file?.url;
+  if (imageBlock && imageBlock.image.type === "file") {
+    return imageBlock.image.file.url;
+  }
+
+  return undefined;
 }

--- a/src/app/utils/notionUtils.ts
+++ b/src/app/utils/notionUtils.ts
@@ -8,7 +8,7 @@ import {
   PartialBlockObjectResponse,
   BlockObjectResponse,
 } from "@notionhq/client/build/src/api-endpoints";
-import { ImageBlock } from "../components/NotionRenderer/types";
+import { ImageBlock, RichTextItem } from "../components/NotionRenderer/types";
 
 export enum NOTION_BLOG_RECORDS_PROPERTIES {
   "ID" = "id",
@@ -76,6 +76,22 @@ export function isBlockObject(
   return block.object === "block";
 }
 
+export function isFullBlock(
+  block: PartialBlockObjectResponse | BlockObjectResponse,
+): block is BlockObjectResponse {
+  return "type" in block;
+}
+
+export function isListItemBlock(
+  block: PartialBlockObjectResponse | BlockObjectResponse,
+): block is BlockObjectResponse &
+  ({ type: "bulleted_list_item" } | { type: "numbered_list_item" }) {
+  return (
+    isFullBlock(block) &&
+    (block.type === "bulleted_list_item" || block.type === "numbered_list_item")
+  );
+}
+
 export function isImageBlock(
   block: PartialBlockObjectResponse | BlockObjectResponse,
 ): block is ImageBlock {
@@ -93,4 +109,31 @@ export function getFirstImageFromListBlockChildren(
   }
 
   return undefined;
+}
+
+export function getImageUrlFromImageData(
+  imageData: ImageBlock["image"],
+): string | null {
+  if (imageData.type === "file") {
+    return imageData.file?.url ?? null;
+  } else if (imageData.type === "external") {
+    return imageData.external?.url ?? null;
+  }
+  return null;
+}
+
+export function getLinkFromRichTextItem(text: RichTextItem): string | null {
+  // First, check if there's a direct href property
+  if (text.href) {
+    return text.href;
+  }
+
+  // For text type, extract link from text.link property
+  if (text.type === "text" && text.text?.link) {
+    return typeof text.text.link === "string"
+      ? text.text.link
+      : text.text.link.url;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## 문제 분석

현재 Notion API에서 받아온 AWS signed URL이 `X-Amz-Expires` 쿼리 파라미터로 인해 만료되면 403 에러를 반환하여 이미지가 표시되지 않음.

## 해결 방안

Next.js API Route를 통해 이미지를 프록시하고, 만료 시 자동으로 Notion API에서 최신 URL을 가져오는 방식으로 구현.

## 구현 단계

### 1. API Route 생성

`/api/notion-image` 엔드포인트 생성:

- 쿼리 파라미터로 `blockId` 받기
- Notion API를 통해 해당 블록의 최신 이미지 URL 획득
- 이미지를 fetch하여 스트리밍으로 응답
- 적절한 캐시 헤더 설정 (30분, `revalidate: 1800`과 일치)
- 에러 처리 (404, 403 등)

### 2. Image 컴포넌트 수정

`src/app/components/NotionRenderer/components/Image.tsx`:

- 이미지 URL을 프록시 URL로 변환 (`/api/notion-image?blockId=${block.id}`)
- Notion 호스팅 이미지만 프록시 사용 (external URL은 그대로 유지)
- `customImage` prop 에 Next.js `<Image>` 사용

### 3. NotionRenderer 통합

`src/app/(record)/records/[slug]/page.tsx`:

- Next.js `<Image>` 컴포넌트를 `customImage` prop으로 전달
- 단, 인라인 함수를 직접 속성으로 넘기는 것은 렌더링 에러가 발생하므로, 별도의 클라이언트 컴포넌트로 분리하여 사용. (NotionImage.tsx)
- 최적화 및 자동 캐싱 활성화

## 기대 효과

- 이미지 만료 문제 완전 해결
- Next.js Image 최적화 자동 적용
- 서버 사이드 캐싱으로 성능 향상
- 외부 서비스 의존성 없음