### PR TITLE
perf: 렌더링 성능 최적화를 위한 번들 및 리소스 최적화

### DIFF
--- a/src/app/(record)/records/[slug]/layout.tsx
+++ b/src/app/(record)/records/[slug]/layout.tsx
@@ -6,6 +6,7 @@ import {
   getTitleFromPageObject,
   isPageObject,
 } from "@/app/utils/notionUtils";
+import "prismjs/themes/prism-tomorrow.css";
 
 export const revalidate = 1800;
 

--- a/src/app/components/RecentRecordsSection.tsx
+++ b/src/app/components/RecentRecordsSection.tsx
@@ -11,17 +11,16 @@ import {
   getTitleFromPageObject,
   isPageObject,
 } from "@/app/utils/notionUtils";
-import { filter, limit, toArray } from "@einere/common-utils";
 
 const RECENT_RECORDS_SECTION_TITLE = "새로운 여정의 기록들";
 const MAX_RECORDS = 5;
 
 export async function RecentRecordsSection() {
-  const { results } = await queryRecordsDataSource();
+  const { results } = await queryRecordsDataSource({
+    page_size: MAX_RECORDS,
+  });
 
-  const recentRecords = toArray(
-    limit(MAX_RECORDS, filter(isPageObject, results)),
-  );
+  const recentRecords = results.filter(isPageObject);
 
   return (
     <SectionWithRecordCards

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { Gowun_Dodum } from "next/font/google";
+import localFont from "next/font/local";
 import "./styles/globals.css";
 import Header from "@/app/components/Header";
 import Footer from "@/app/components/Footer";
-import QueryProvider from "@/app/providers/query-provider";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -12,6 +12,28 @@ const gowunDodum = Gowun_Dodum({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-gowun-dodum",
+  preload: true,
+});
+
+const d2Coding = localFont({
+  src: [
+    {
+      path: "../../public/fonts/D2Coding/D2Coding-subset.woff2",
+      weight: "400",
+    },
+    {
+      path: "../../public/fonts/D2Coding/D2Coding-full.woff2",
+      weight: "400",
+    },
+  ],
+  variable: "--font-d2coding",
+  display: "swap",
+});
+
+const fZuanSu = localFont({
+  src: "../../public/fonts/FZuanSu/FZuanSu-subset.woff2",
+  variable: "--font-fzuansu",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -49,13 +71,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko" data-theme="pink" className={gowunDodum.variable}>
+    <html
+      lang="ko"
+      data-theme="pink"
+      className={`${gowunDodum.variable} ${d2Coding.variable} ${fZuanSu.variable}`}
+    >
       <body className="antialiased">
-        <QueryProvider>
-          <Header />
-          {children}
-          <Footer />
-        </QueryProvider>
+        <Header />
+        {children}
+        <Footer />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,4 @@
-import {
-  RecentRecordsSection,
-  RecentRecordsSectionSkeleton,
-} from "@/app/components/RecentRecordsSection";
-import { Suspense } from "react";
+import { RecentRecordsSection } from "@/app/components/RecentRecordsSection";
 
 export default function HomePage() {
   return (
@@ -11,9 +7,7 @@ export default function HomePage() {
         이 공간을 찾아주신 당신을 환영합니다.
       </h1>
       <div className="mx-auto max-w-[768px] px-4 pb-24 lg:px-0">
-        <Suspense fallback={<RecentRecordsSectionSkeleton />}>
-          <RecentRecordsSection />
-        </Suspense>
+        <RecentRecordsSection />
       </div>
     </main>
   );

--- a/src/app/search/SearchContent.tsx
+++ b/src/app/search/SearchContent.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { getTitleFromPageObject, isPageObject } from "@/app/utils/notionUtils";
+import { useNotionSearch } from "@/app/hooks/useNotionSearch";
+import Link from "next/link";
+import { useDebounce } from "@/app/hooks/useDebounce";
+import { isEmptyArray, isExist } from "@einere/common-utils";
+
+export default function SearchContent() {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query, 1000);
+
+  const { data, isFetching } = useNotionSearch(debouncedQuery);
+
+  return (
+    <>
+      <h1 className="mt-16 mb-6">찾고 싶은게 무엇인가요? 🔍</h1>
+      <p className="mb-6">제목을 기반으로 기록들을 찾아볼 수 있어요.</p>
+      <form
+        role="search"
+        onSubmit={(e) => {
+          e.preventDefault();
+          return false;
+        }}
+        className="mb-6 grid grid-cols-[minmax(100px,_auto)_1fr]"
+      >
+        <label htmlFor="search-by-title">제목</label>
+        <input
+          id="search-by-title"
+          type="search"
+          onChange={(e) => setQuery(e.target.value)}
+          className="rounded-sm border-1 border-solid border-gray-400"
+        />
+      </form>
+
+      <ul>
+        {(() => {
+          if (isFetching) {
+            return <p>기록들을 찾아보는중...</p>;
+          }
+
+          if (!isExist(data)) {
+            return null;
+          }
+
+          if (isEmptyArray(data)) {
+            return <p>해당 제목으로 기록을 아무것도 찾을 수 없었어요.</p>;
+          }
+
+          return data.filter(isPageObject).map((page) => (
+            <li key={page.id}>
+              <Link href={`/records/${page.id}`}>
+                {getTitleFromPageObject(page)}
+              </Link>
+            </li>
+          ));
+        })()}
+      </ul>
+    </>
+  );
+}
+

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,63 +1,12 @@
-"use client";
-
-import { useState } from "react";
-import { getTitleFromPageObject, isPageObject } from "@/app/utils/notionUtils";
-import { useNotionSearch } from "@/app/hooks/useNotionSearch";
-import Link from "next/link";
-import { useDebounce } from "@/app/hooks/useDebounce";
-import { isEmptyArray, isExist } from "@einere/common-utils";
+import QueryProvider from "@/app/providers/query-provider";
+import SearchContent from "./SearchContent";
 
 export default function SearchPage() {
-  const [query, setQuery] = useState("");
-  const debouncedQuery = useDebounce(query, 1000);
-
-  const { data, isFetching } = useNotionSearch(debouncedQuery);
-
   return (
     <main className="mx-auto min-h-screen max-w-[768px] px-4 lg:px-0">
-      <h1 className="mt-16 mb-6">찾고 싶은게 무엇인가요? 🔍</h1>
-      <p className="mb-6">제목을 기반으로 기록들을 찾아볼 수 있어요.</p>
-
-      <form
-        role="search"
-        onSubmit={(e) => {
-          e.preventDefault();
-          return false;
-        }}
-        className="mb-6 grid grid-cols-[minmax(100px,_auto)_1fr]"
-      >
-        <label htmlFor="search-by-title">제목</label>
-        <input
-          id="search-by-title"
-          type="search"
-          onChange={(e) => setQuery(e.target.value)}
-          className="rounded-sm border-1 border-solid border-gray-400"
-        />
-      </form>
-
-      <ul>
-        {(() => {
-          if (isFetching) {
-            return <p>기록들을 찾아보는중...</p>;
-          }
-
-          if (!isExist(data)) {
-            return null;
-          }
-
-          if (isEmptyArray(data)) {
-            return <p>해당 제목으로 기록을 아무것도 찾을 수 없었어요.</p>;
-          }
-
-          return data.filter(isPageObject).map((page) => (
-            <li key={page.id}>
-              <Link href={`/records/${page.id}`}>
-                {getTitleFromPageObject(page)}
-              </Link>
-            </li>
-          ));
-        })()}
-      </ul>
+      <QueryProvider>
+        <SearchContent />
+      </QueryProvider>
     </main>
   );
 }

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -1,8 +1,6 @@
 @import "tailwindcss";
-@import "./font.css";
 @import "./theme.css" layer(theme);
 @import "./utility.css";
-@import "prismjs/themes/prism-tomorrow.css";
 
 @layer base {
   :root {

--- a/src/app/styles/theme.css
+++ b/src/app/styles/theme.css
@@ -2,8 +2,8 @@
 @theme {
   /* Font */
   --font-sans: var(--font-gowun-dodum);
-  --font-mono: D2Coding;
-  --font-chiness: FZuanSu;
+  --font-mono: var(--font-d2coding);
+  --font-chiness: var(--font-fzuansu);
 
   /* Color */
   --color-background: var(--background);


### PR DESCRIPTION
- React Query 조건부 로딩: 루트 레이아웃에서 제거하고 검색 페이지만 사용
  - 초기 JavaScript 번들 크기 약 30-40KB 감소 (TTB 개선)

- 로컬 폰트 최적화: next/font/local로 전환하여 자동 프리로드 및 최적화
  - D2Coding, FZuanSu 폰트를 next/font/local로 마이그레이션
  - FCP 100-200ms 개선 예상

- PrismJS CSS 조건부 로드: 코드 블록이 있는 레코드 페이지만 로드
  - 초기 CSS 크기 약 5-10KB 감소

- 검색 페이지 리팩토링: 서버 컴포넌트와 클라이언트 컴포넌트 분리
  - SearchContent를 별도 클라이언트 컴포넌트로 분리
  - QueryProvider를 검색 페이지만 감싸도록 변경

- 루트 페이지 최적화: Suspense 제거로 완전한 SSG 적용

변경된 파일:
- src/app/layout.tsx: QueryProvider 제거, 로컬 폰트 추가
- src/app/page.tsx: Suspense 제거
- src/app/search/page.tsx: 서버 컴포넌트로 변경, SearchContent 분리
- src/app/search/SearchContent.tsx: 새 파일 (검색 로직 클라이언트 컴포넌트)
- src/app/styles/globals.css: PrismJS CSS import 제거
- src/app/styles/theme.css: 폰트 변수명 업데이트
- src/app/(record)/records/[slug]/layout.tsx: PrismJS CSS 추가