### PR TITLE
Fix: OpenGraph 썸네일 이미지 표시 문제 해결

### DIFF
--- a/src/app/(record)/records/[slug]/page.tsx
+++ b/src/app/(record)/records/[slug]/page.tsx
@@ -9,7 +9,6 @@ import {
 import { Comments } from "@/app/components/Comments";
 import {
   getDescriptionFromPageObject,
-  getFirstImageFromListBlockChildren,
   getFirstImageBlockIdFromListBlockChildren,
   getTitleFromPageObject,
 } from "@/app/utils/notionUtils";
@@ -38,18 +37,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { page, blockChildren } = await getCachedPageData(slug);
 
   const title = getTitleFromPageObject(page) ?? undefined;
-  const imageUrl = getFirstImageFromListBlockChildren(blockChildren);
   const firstImageBlockId =
     getFirstImageBlockIdFromListBlockChildren(blockChildren);
   const description = getDescriptionFromPageObject(page);
 
-  const baseUrl =
-    process.env.NEXT_PUBLIC_SITE_URL ??
-    (process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : "http://localhost:3000");
-  const proxiedOgImage = firstImageBlockId
-    ? `${baseUrl}/api/notion-image?blockId=${firstImageBlockId}`
+  // firstImageBlockId가 있으면 항상 프록시 URL 사용 (모든 이미지 타입 지원)
+  // 상대 경로를 사용하면 Next.js가 root layout의 metadataBase를 자동으로 활용하여 절대 URL 생성
+  const ogImageUrl = firstImageBlockId
+    ? `/api/notion-image?blockId=${firstImageBlockId}`
     : undefined;
 
   return {
@@ -59,19 +54,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       type: "website",
       title: title,
       description: description,
-      images: proxiedOgImage
+      images: ogImageUrl
         ? [
             {
-              url: proxiedOgImage,
+              url: ogImageUrl,
             },
           ]
-        : imageUrl
-          ? [
-              {
-                url: imageUrl,
-              },
-            ]
-          : [],
+        : [],
     },
   };
 }


### PR DESCRIPTION
# Fix: OpenGraph 썸네일 이미지 표시 문제 해결

## 문제 상황

기록 페이지의 OpenGraph 썸네일 이미지가 소셜 미디어 플랫폼(페이스북, 트위터 등)에서 제대로 표시되지 않는 문제가 있었습니다.

### 원인 분석

1. **환경 변수 의존성**: `NEXT_PUBLIC_SITE_URL` 또는 `VERCEL_URL`에 의존하여 프로덕션 환경에서 URL이 제대로 생성되지 않을 수 있었습니다.
2. **Notion 직접 URL 사용**: Notion의 직접 이미지 URL을 fallback으로 사용했는데, 이는 외부 크롤러가 접근할 수 없어 OpenGraph 이미지가 표시되지 않았습니다.
3. **metadataBase 미활용**: Root layout에 설정된 `metadataBase`를 활용하지 않고 수동으로 절대 URL을 생성하고 있었습니다.

## 해결 방법

### 주요 변경사항

1. **metadataBase 자동 활용**
   - 상대 경로(`/api/notion-image?blockId=...`)를 사용하여 Next.js가 root layout의 `metadataBase`를 자동으로 활용하도록 변경
   - 환경 변수 의존성 제거로 유지보수성 향상

2. **프록시 URL 통일**
   - 모든 이미지를 프록시 URL(`/api/notion-image`)을 통해 제공
   - Notion 직접 URL fallback 제거
   - `file` 및 `external` 타입 이미지 모두 지원

3. **코드 정리**
   - 사용하지 않는 `getFirstImageFromListBlockChildren` import 제거
   - 불필요한 `imageUrl` 변수 제거

## 변경된 파일

- `src/app/(record)/records/[slug]/page.tsx`

## 테스트

- [x] 로컬 환경에서 OpenGraph 메타 태그 확인
- [x] 절대 URL이 올바르게 생성되는지 확인 (`https://www.einere.me/api/notion-image?blockId=...`)
- [x] 프록시 URL이 정상적으로 작동하는지 확인

## 예상 효과

- 소셜 미디어 플랫폼에서 OpenGraph 썸네일 이미지가 정상적으로 표시됨
- 환경 변수 설정 없이도 올바른 절대 URL 생성
- 코드 간소화 및 유지보수성 향상
